### PR TITLE
Add DEBUG flag and exclude GoogleService plist in debug target

### DIFF
--- a/Little Go.xcodeproj/project.pbxproj
+++ b/Little Go.xcodeproj/project.pbxproj
@@ -3496,6 +3496,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
+				EXCLUDED_SOURCE_FILE_NAMES = "GoogleService-Info.plist";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = src/main/Prefix.pch;
 				INFOPLIST_FILE = resource/plist/Info.plist;
@@ -3572,6 +3573,10 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-D",
+					DEBUG,
+				);
 				OTHER_LDFLAGS = "";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Little Go.xcodeproj/project.pbxproj
+++ b/Little Go.xcodeproj/project.pbxproj
@@ -3573,10 +3573,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-D",
-					DEBUG,
-				);
 				OTHER_LDFLAGS = "";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/src/main/ApplicationDelegate.mm
+++ b/src/main/ApplicationDelegate.mm
@@ -372,7 +372,7 @@ static std::streambuf* outputPipeStreamBuffer = nullptr;
 // -----------------------------------------------------------------------------
 - (void) setupCrashReporting
 {
-#ifndef DEBUG
+#ifdef LITTLEGO_NDEBUG
 #ifndef LITTLEGO_UNITTESTS
   // One way to disable everything programmatically is this:
   //   [[FIRApp defaultApp] setDataCollectionDefaultEnabled:NO];

--- a/src/main/ApplicationDelegate.mm
+++ b/src/main/ApplicationDelegate.mm
@@ -374,8 +374,6 @@ static std::streambuf* outputPipeStreamBuffer = nullptr;
 {
 #ifndef DEBUG
 #ifndef LITTLEGO_UNITTESTS
-  // TODO: Conditional compile this only when building for App Distribution
-
   // One way to disable everything programmatically is this:
   //   [[FIRApp defaultApp] setDataCollectionDefaultEnabled:NO];
   // Unfortunately this also disables crash reporting.

--- a/src/main/ApplicationDelegate.mm
+++ b/src/main/ApplicationDelegate.mm
@@ -372,6 +372,7 @@ static std::streambuf* outputPipeStreamBuffer = nullptr;
 // -----------------------------------------------------------------------------
 - (void) setupCrashReporting
 {
+#ifndef DEBUG
 #ifndef LITTLEGO_UNITTESTS
   // TODO: Conditional compile this only when building for App Distribution
 
@@ -383,6 +384,7 @@ static std::streambuf* outputPipeStreamBuffer = nullptr;
 
   CrashReportingHandler* crashReportingHandler = [[[CrashReportingHandler alloc] initWithModel:self.crashReportingModel] autorelease];
   [crashReportingHandler handleUnsentCrashReportsOrDoNothing];
+#endif
 #endif
 }
 


### PR DESCRIPTION
- Adds `DEBUG` compiler flag for use in debug builds only (note we can do something similar for `RELEASE`)
- Excludes `GoogleService-Info.plist` in debug builds making the project buildable from scratch (got an error about that file missing otherwise)
- Skips `setupCrashReporting` in debug mode