### PR TITLE
Make space between toolbar items flexible

### DIFF
--- a/src/play/boardposition/BoardPositionToolbarController.m
+++ b/src/play/boardposition/BoardPositionToolbarController.m
@@ -211,10 +211,9 @@
 // -----------------------------------------------------------------------------
 - (void) setupBarButtonItems
 {
-  UIBarButtonItem* navigationBarButtonSpacer = [[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace
+  UIBarButtonItem* navigationBarButtonSpacer = [[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace
                                                                                               target:nil
                                                                                               action:nil] autorelease];
-  navigationBarButtonSpacer.width = [AutoLayoutUtility horizontalSpacingSiblings];
 
   enum BoardPositionNavigationDirection direction = BoardPositionNavigationDirectionBackward;
   [self addButtonWithImageNamed:rewindToStartButtonIconResource withSelector:@selector(rewindToStart:) navigationDirection:direction];
@@ -225,6 +224,7 @@
   [self addButtonWithImageNamed:forwardButtonIconResource withSelector:@selector(nextBoardPosition:) navigationDirection:direction];
   [self.navigationBarButtonItems addObject:navigationBarButtonSpacer];
   [self addButtonWithImageNamed:forwardToEndButtonIconResource withSelector:@selector(fastForwardToEnd:) navigationDirection:direction];
+  [self.navigationBarButtonItems addObject:navigationBarButtonSpacer];
 }
 
 // -----------------------------------------------------------------------------
@@ -277,6 +277,12 @@
                      withSecondView:self.view
                         onAttribute:NSLayoutAttributeCenterY
                    constraintHolder:self.view];
+  
+  UIBarButtonItem* navigationBarFixedSpacer = [[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace
+                                                                                             target:nil
+                                                                                             action:nil] autorelease];
+  navigationBarFixedSpacer.width = self.currentBoardPositionViewController.view.intrinsicContentSize.width;
+  [self.navigationBarButtonItems addObject:navigationBarFixedSpacer];
 }
 
 #pragma mark - Updaters

--- a/src/play/boardposition/BoardPositionToolbarController.m
+++ b/src/play/boardposition/BoardPositionToolbarController.m
@@ -278,6 +278,8 @@
                         onAttribute:NSLayoutAttributeCenterY
                    constraintHolder:self.view];
   
+  // Add a fixed space equal to the width of the current board position element to
+  // the toolbar so that the toolbar items can space evenly in the remaining space
   UIBarButtonItem* navigationBarFixedSpacer = [[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace
                                                                                              target:nil
                                                                                              action:nil] autorelease];


### PR DESCRIPTION
I made the space between the toolbar items flexible, but I also had to add a fixed width space equal to the current board position element's width due to it being a subview.

Another solution here would be to put the current board position into a bar button item with a custom view, but that would be more work and I wasn't sure if there was a particular reason you had decided to not do that. Can look into that if you prefer that solution, though.

![Simulator Screen Shot - iPhone 8 - 2021-02-01 at 12 03 12](https://user-images.githubusercontent.com/1389312/106492079-87667980-6485-11eb-931f-04b28fad024a.png)

Fixes #346.